### PR TITLE
Fixed identifying gene column in activity file

### DIFF
--- a/crc/resources/crc_utils.py
+++ b/crc/resources/crc_utils.py
@@ -151,7 +151,7 @@ def gene_to_enhancer(genome, enhancer_file, activity_path):
         # (basically not NM or NR and not a numeral)
         for i in range(len(activity_table[0])):
             # Assumes refseq
-            if activity_table[0][i][0:2] != 'NM' and activity_table[0][i][0:2] != 'NR':
+            if activity_table[0][i][0:2] != 'NM' and activity_table[0][i][0:2] != 'NR' and not activity_table[0][i][0:2].isdigit():
                 gene_col = i
                 break
         print(


### PR DESCRIPTION
Made sure that a column of numbers in an activity file will not be identified as the column containing gene names. The code now matches the comment.